### PR TITLE
.one() should not return a list, since it will only contain 1 item

### DIFF
--- a/pyrebase/pyrebase.py
+++ b/pyrebase/pyrebase.py
@@ -101,12 +101,8 @@ class Firebase():
         if request_object.status_code != 200:
             return request_json
 
-        request_list = []
-
         request_json["id"] = item_id
-        request_list.append(request_json)
-
-        return request_list
+        return request_json
 
     def sort(self, child, prop, start=None, limit=None, direction=None):
         if start and limit and direction:


### PR DESCRIPTION
I just though it was a bit unnecessary for it to return a list, that you then have to unpack on the receiving end.