### PR TITLE
A couple of changes to the .one() method

### DIFF
--- a/pyrebase/pyrebase.py
+++ b/pyrebase/pyrebase.py
@@ -101,12 +101,10 @@ class Firebase():
         if request_object.status_code != 200:
             return request_json
 
-        request_list = []
+        if isinstance(request_json, dict):
+            request_json["id"] = item_id
 
-        request_json["id"] = item_id
-        request_list.append(request_json)
-
-        return request_list
+        return request_json
 
     def sort(self, child, prop, start=None, limit=None, direction=None):
         if start and limit and direction:


### PR DESCRIPTION
- Don't return a list, there will at maximum be one item returned.
- Don't try to set the 'id' property on the output object, if it's not a dict

This is a bit of an extension to the change suggested in #3. I am needing a way to get a single key with a string value out of Firebase, and if I tried to access that key directly with Pyrebase, it will just fail because it tries to set the `id` attribute on a string. To correct that I have added a check to see if it's a dict before trying to set the id.
Perhaps that's worth adding to `all()` and `sort()` as well, if you are up for that idea?