### PR TITLE
Add generic .get() method

### DIFF
--- a/pyrebase/pyrebase.py
+++ b/pyrebase/pyrebase.py
@@ -1,6 +1,7 @@
 from operator import itemgetter
 from requests_futures.sessions import FuturesSession
 from firebase_token_generator import create_token
+from urllib.parse import urlencode
 import re
 
 request = FuturesSession()
@@ -144,6 +145,12 @@ class Firebase():
             raise TypeError("Property types don't match.")
 
         return request_list
+
+    def get(self, child, parameters={}):
+        parameters['auth'] = self.token
+        request_ref = '{0}{1}.json?{2}'.format(self.fire_base_url, child, urlencode(parameters))
+        request_object = request.get(request_ref).result()
+        return request_object.json()
 
     def post(self, child, data):
         request_ref = '{0}{1}.json?auth={2}'.format(self.fire_base_url, child, self.token)


### PR DESCRIPTION
So, here's another PR from me...

I am in the need of getting the last object in a list sorted by the key, and I couldn't get the `sort()` method to acknowledge using `$key` as the sort key. Instead I thought it may make sense to have a generic GET method, like the POST, PUT, PATCH and DELETE methods, which could enable me to basically call: `https://<project ID>.firebaseio.com/path/to/entries.json?auth=<token>&limitToLast=1&orderBy="$key"`.

The method has not been added to the README file, as I'm unsure where it would fit in best. Do you have any thought on that?