### PR TITLE
Let .query() take any number of arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ To retrieve one entry just expand the path.
 
 ```python
 one_user = admin.query("users/Marty").get()
+# or:
+one_user = admin.query("users", "Marty").get()
 ```
 
 #### keys

--- a/pyrebase/pyrebase.py
+++ b/pyrebase/pyrebase.py
@@ -71,8 +71,8 @@ class Firebase():
         self.buildQuery["limitToLast"] = limitLast
         return self
 
-    def query(self, child):
-        self.child = child
+    def query(self, *args):
+        self.child = "/".join(args)
         return self
 
     def get(self):


### PR DESCRIPTION
Since `query()` doesn't take any other arguments than the path in Firebase, it may as well make it a bit more convenient.

In my current use case for Firebase, I often find that I need to access a path such as `projects/<project_id>/data`, which would require me to do some string formatting or concatenation. This change would allow me to call `query('projects', project_id, 'data')` and let Pyrebase assemble it to the path.