### PR TITLE
Add shallow() to query calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,15 @@ users_by_score = admin.query("users").orderBy("score").limitToFirst(5).get()
 ```
 This query returns the first five users ordered by score.
 
+#### shallow
+
+Fetches only the keys and returns them in a list
+
+Example:
+```python
+user_ids = admin.query("users").shallow().get()
+```
+
 ## Common Errors
 
 ### Index not defined

--- a/pyrebase/pyrebase.py
+++ b/pyrebase/pyrebase.py
@@ -71,6 +71,10 @@ class Firebase():
         self.buildQuery["limitToLast"] = limitLast
         return self
 
+    def shallow(self):
+        self.buildQuery["shallow"] = True
+        return self
+
     def query(self, child):
         self.child = child
         return self
@@ -99,6 +103,9 @@ class Firebase():
             if self.buildQuery["orderBy"] == "$key":
                 self.buildQuery["orderBy"] = "key"
             results = sorted(results, key=itemgetter(self.buildQuery["orderBy"]))
+        # return keys if shallow is enabled
+        if self.buildQuery and self.buildQuery["shallow"]:
+            return results.keys()
         return results
 
     def info(self):


### PR DESCRIPTION
In the interest of reusing the concepts of the API, I have added a `shallow()` method which can be used along with `query()`. Unfortunately it can't be used at the same time as some of the query parameters, in those cases Firebase responds with `{'error': "Mixing 'shallow' and querying parameters is not supported"}`. I don't know if that is something to be handled before sending of the query, or if we should keep it separated with the `keys()` method just to avoid the problem all together?