### PR TITLE
Fixed sample usage of "send_email_verification"

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Note: Make sure you have the Email/password provider enabled in your Firebase da
 #### Verifying emails
 
 ```python
-auth.send_email_verification(email)
+auth.send_email_verification(user['idToken'])
 ```
 
 #### Sending password reset emails

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ db.child("users").push(data)
 
 #### set
 
-To create your own keys use the ```set()``` method. The key in the example below is "Marty".
+To create your own keys use the ```set()``` method. The key in the example below is "Morty".
 
 ```python
 data = {"Morty": {"name": "Mortimer 'Morty' Smith"}}


### PR DESCRIPTION
"auth.send_email_verification" method actually uses the user ID token, instead of his email
