### PR TITLE
Fix ProtocolError using GAE standard environment

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,5 +15,5 @@ setup(
     ],
     keywords='Firebase',
     packages=find_packages(exclude=['tests']),
-    install_requires=['requests', 'sseclient', 'gcloud', 'oauth2client']
+    install_requires=['requests', 'sseclient', 'gcloud', 'oauth2client', 'requests_toolbelt']
 )


### PR DESCRIPTION
Fix error on Google App Engine standard environment, this behavior was fixed on [urllib3#763](https://github.com/shazow/urllib3/pull/763) but we need [patching](https://toolbelt.readthedocs.io/en/latest/adapters.html#appengineadapter) requests to work propertly.