### PR TITLE
Fix TypeError: sequence item 0: expected string, int found.

### DIFF
--- a/pyrebase/pyrebase.py
+++ b/pyrebase/pyrebase.py
@@ -207,7 +207,7 @@ class Database:
         return self
 
     def child(self, *args):
-        new_path = "/".join(args)
+        new_path = "/".join([str(arg) for arg in args])
         if self.path:
             self.path += "/{}".format(new_path)
         else:


### PR DESCRIPTION
When an **int** argument is passed as a child node, Pyrebase throws an error. Should be fixed now.