### PR TITLE
Add Ability to use Service Accounts from JSON string or Python dict

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,25 @@ firebase = pyrebase.initialize_app(config)
 Adding a service account will authenticate as an admin by default for all database queries, check out the
 [Authentication documentation](#authentication) for how to authenticate users.
 
+You may also pass a JSON string or Python dictionary containing service account credentials using `serviceAccountJson`.
+
+```python
+import pyrebase
+import os
+
+service_account = os.environ['FBASE_SERVICE_ACCOUNT_JSON']
+
+config = {
+  "apiKey": "apiKey",
+  "authDomain": "projectId.firebaseapp.com",
+  "databaseURL": "https://databaseName.firebaseio.com",
+  "storageBucket": "projectId.appspot.com",
+  "serviceAccountJson": service_account
+}
+
+firebase = pyrebase.initialize_app(config)
+```
+
 ### Use Services
 
 A Pyrebase app can use multiple Firebase services.

--- a/pyrebase/pyrebase.py
+++ b/pyrebase/pyrebase.py
@@ -45,6 +45,14 @@ class Firebase:
                 "https://www.googleapis.com/auth/cloud-platform"
             ]
             self.credentials = ServiceAccountCredentials.from_json_keyfile_name(config["serviceAccount"], scopes)
+        elif config.get("serviceAccountJson"):
+            self.service_account_json = config["serviceAccountJson"]
+            scopes = [
+                'https://www.googleapis.com/auth/firebase.database',
+                'https://www.googleapis.com/auth/userinfo.email',
+                "https://www.googleapis.com/auth/cloud-platform"
+            ]
+            self.credentials = ServiceAccountCredentials.from_json(config["serviceAccountJson"], scopes)
         if is_appengine_sandbox():
             # Fix error in standard GAE environment
             # is releated to https://github.com/kennethreitz/requests/issues/3187


### PR DESCRIPTION
This PR adds an accepted config value named "serviceAccountJson" that runs `ServiceAccountCredentials.from_json` instead of `ServiceAccountCredentials.from_json_keyfile_name`.
This other function accepts both JSON formatted strings and Python dictionaries.

See https://oauth2client.readthedocs.io/en/latest/source/oauth2client.service_account.html#oauth2client.service_account.ServiceAccountCredentials.from_json for more info.