### PR TITLE
Correctly serialize booleans for order_by queries

### DIFF
--- a/pyrebase/pyrebase.py
+++ b/pyrebase/pyrebase.py
@@ -233,6 +233,8 @@ class Database:
         for param in list(self.build_query):
             if type(self.build_query[param]) is str:
                 parameters[param] = quote('"' + self.build_query[param] + '"')
+            elif type(self.build_query[param]) is bool:
+                parameters[param] = "true" if self.build_query[param] else "false"
             else:
                 parameters[param] = self.build_query[param]
         # reset path and build_query for next query


### PR DESCRIPTION
I hit on an interesting issue when trying to order by a Boolean field in firebase.
When writing something like `order_by_child('field').equal_to(True)` one gets "equal_to=True" as a query param, but the correct json serialization is "true" without the upper case T.

This commit adds a special case if the type of the order param is a Boolean.