### PR TITLE
Handle empty firebase responses in val

### DIFF
--- a/pyrebase/pyrebase.py
+++ b/pyrebase/pyrebase.py
@@ -453,6 +453,9 @@ class PyreResponse:
         if isinstance(self.pyres, list):
             # unpack pyres into OrderedDict
             pyre_list = []
+            # if firebase response was empty
+            if len(self.pyres) == 0:
+                return OrderedDict(pyre_list)
             # if firebase response was a list
             if isinstance(self.pyres[0].key(), int):
                 for pyre in self.pyres:


### PR DESCRIPTION
Currently, the `val` method crashes if the response from firebase is empty.

This fix is not perfect, because when the list is empty there is no good way of knowing whether the correct return value from `val` should be a list or an OrderedDict.
So I see you if you don't want to merge this fix, but I'd like to know if you think the `val` method should handle empty responses without crashing, or if one should instead check the data explicitly before calling val.
