### PR TITLE
Fix timestamp test

### DIFF
--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -72,7 +72,7 @@ class TestJsonKwargs:
 
     def decoder(self, obj):
         if '__type__' in obj and obj['__type__'] == datetime.datetime.__name__:
-            return datetime.datetime.utcfromtimestamp(obj['value'])
+            return datetime.datetime.fromtimestamp(obj['value'])
         return obj
 
     def test_put_fail(self, db_sa):


### PR DESCRIPTION
Dear pyrebase team,

In my environment, pytest always failed.
Probably, my timezone is JST, so ```datetime.utcfromtimestmap()``` got a strange date.
(I think if using timezone utc, this test works.)
```
$ date
2017年 2月12日 日曜日 17時27分40秒 JST
$ pytest -sv tests/test_database.py::TestJsonKwargs::test_put_then_get_succeed
==================================================== test session starts =====================================================
platform darwin -- Python 3.5.2, pytest-3.0.6, py-1.4.32, pluggy-0.4.0 -- /Users/sho/.pyenv/versions/3.5.2/bin/python3.5
cachedir: .cache
rootdir: /Users/sho/github/Pyrebase, inifile:
collected 4 items

tests/test_database.py::TestJsonKwargs::test_put_then_get_succeed FAILED

========================================================== FAILURES ==========================================================
__________________________________________ TestJsonKwargs.test_put_then_get_succeed __________________________________________

self = <tests.test_database.TestJsonKwargs object at 0x10ff28a20>, db_sa = <function db_sa.<locals>.<lambda> at 0x10feb1048>

    def test_put_then_get_succeed(self, db_sa):
        v = {'another_datetime': datetime.datetime.now()}
        db_sa().set(v, json_kwargs={'default': self.encoder})
>       assert db_sa().get(json_kwargs={'object_hook': self.decoder}).val() == v
E       assert OrderedDict([...44, 853748))]) == {'another_date..., 44, 853748)}
E         Differing items:
E         {'another_datetime': datetime.datetime(2017, 2, 12, 8, 27, 44, 853748)} != {'another_datetime': datetime.datetime(2017, 2, 12, 17, 27, 44, 853748)}
E         Full diff:
E         + {'another_datetime': datetime.datetime(2017, 2, 12, 17, 27, 44, 853748)}
E         - OrderedDict([('another_datetime',
E         -               datetime.datetime(2017, 2, 12, 8, 27, 44, 853748))])

tests/test_database.py:90: AssertionError
```

```datetime.utcfromtimestamp()``` expected only utctimestamp, so I tried below, but It does not work.

```
     def test_put_then_get_succeed(self, db_sa):
-        v = {'another_datetime': datetime.datetime.now()}
+        v = {'another_datetime': datetime.datetime.utcnow()}
         db_sa().set(v, json_kwargs={'default': self.encoder})
         assert db_sa().get(json_kwargs={'object_hook': self.decoder}).val() == v
```
Because ```utcfromtimestamp()``` gots date by "local" time, then It must be```v !=datetime.now()```

I fix this problem by this pull-request, change ```datetime.utcfromtimestamp()``` to ```datetime.fromtimestamp()```

I also consider about change ```datetime.now()``` to ```datetime.utcnow()```, then we do not consider about timezone!

This is my first-time pull-requests, sorry if I came off as rude.

Regards,