### PR TITLE
Allow giving parameter of requests.timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,25 @@ all_user_ids = db.child("users").shallow().get()
 
 Note: ```shallow()``` can not be used in conjunction with any complex queries.
 
+#### set_timeout
+
+To set the requests(get, set, push, remove) timeout use the ```set_timeout()``` method.
+
+You can set timeout, more than 0 value of float.
+
+See [Quickstart, Requests, Timeouts](http://docs.python-requests.org/en/master/user/quickstart/#timeouts).
+
+```python
+# set timeouts to instance
+db.set_timeout(timeout=0.001)
+# will raise requests.exceptions.ConnectTimeout.
+db.get("users")
+# Arg:timeout overwrites set_timeout() value, will success.
+db.get("users", timeout=60)
+# set timeout=None, Timeout is not set(default).
+db.set_timeout(None)
+```
+
 #### streaming
 
 You can listen to live changes to your data with the ```stream()``` method.


### PR DESCRIPTION
Dear pyrebase team,

I add a timeout parameter to requests. Now, requests.get, post, and other methods have no timeout parameter and sometimes hung up at those methods.

I tried to below,
- Add argument "timeout" in basic methods(get, set, update, push, remove).
- Add "set_timeout" method in Database

Usage, in pytest/database_test.py,
```
    def test_get_failed_with_set_timeout(self, db_sa):
        instance = db_sa().set_timeout(timeout=0.001)
        with pytest.raises(ConnectTimeout):
            instance.get().val()

    def test_get_failed_with_timeout_arg(self, db_sa):
        with pytest.raises(ConnectTimeout):
            db_sa().get(timeout=0.001).val()
```

I also add some document to README.md.

Regards,