### PR TITLE
Add simplejson support if available

### DIFF
--- a/pyrebase/pyrebase.py
+++ b/pyrebase/pyrebase.py
@@ -6,7 +6,10 @@ try:
     from urllib.parse import urlencode, quote
 except:
     from urllib import urlencode, quote
-import json
+try:
+    import simplejson as json
+except:
+    import json
 import math
 from random import uniform
 import time


### PR DESCRIPTION
I'd like to be able to use the simplejson serializer, especially because of its `Decimal` support. Could we use it when available?