### PR TITLE
Add deep path support on orderBy

### DIFF
--- a/pyrebase/pyrebase.py
+++ b/pyrebase/pyrebase.py
@@ -282,8 +282,18 @@ class Database:
             elif build_query["orderBy"] == "$value":
                 sorted_response = sorted(request_dict.items(), key=lambda item: item[1])
             else:
-                sorted_response = sorted(request_dict.items(), key=lambda item: item[1][build_query["orderBy"]])
+                path = build_query["orderBy"].split("/")
+                sorted_response = sorted(request_dict.items(), key=lambda item: self._walk(item[1], path))
         return PyreResponse(convert_to_pyre(sorted_response), query_key)
+
+    def _walk(self, obj, path):
+        if path[0] in obj:
+            if len(path) == 1:
+                return obj[path[0]]
+            else:
+                return self._walk(obj[path[0]], path[1:])
+        else:
+            raise Exception("Keys '{}' not found in {}".format(path[0], obj))
 
     def push(self, data, token=None, json_kwargs={}):
         request_ref = self.check_token(self.database_url, self.path, token)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
-requests==2.11.1
+requests==2.20
 gcloud==0.17.0
 oauth2client==3.0.0
 requests-toolbelt==0.7.0
 python-jwt==2.0.1
 pycrypto==2.6.1
+rsa>=4.7 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ requests-toolbelt==0.7.0
 python-jwt==2.0.1
 pycrypto==2.6.1
 rsa>=4.7 # not directly required, pinned by Snyk to avoid a vulnerability
+urllib3>=1.25.9 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/setup.py
+++ b/setup.py
@@ -2,25 +2,25 @@ from setuptools import setup, find_packages
 
 setup(
     name='Pyrebase',
-    version='3.0.27',
-    url='https://github.com/thisbejim/Pyrebase',
-    description='A simple python wrapper for the Firebase API',
-    author='James Childs-Maidment',
+    version='3.1.0',
+    url='https://github.com/digitake/Pyrebase',
+    description='A forked of thisbejim of a simple python wrapper for the Firebase API',
+    author='Digitake',
     license='MIT',
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.6',
     ],
     keywords='Firebase',
     packages=find_packages(exclude=['tests']),
     install_requires=[
-        'requests==2.11.1',
-        'gcloud==0.17.0',
-        'oauth2client==3.0.0',
-        'requests_toolbelt==0.7.0',
-        'python_jwt==2.0.1',
-        'pycryptodome==3.4.3'
+        'requests==2.20.9',
+        'gcloud==0.18.3',
+        'oauth2client==4.1.3',
+        'requests_toolbelt==0.8.0',
+        'python_jwt==3.2.3',
+        'pycryptodome==3.7.0'
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     keywords='Firebase',
     packages=find_packages(exclude=['tests']),
     install_requires=[
-        'requests==2.20.9',
+        'requests==2.20.0',
         'gcloud==0.18.3',
         'oauth2client==4.1.3',
         'requests_toolbelt==0.8.0',


### PR DESCRIPTION
Dear Pyrebase team,

I happen to use pyrebase module for my project. However, one of the feature i need is to order object by deep key path. This is already support by new version of firebase but doesn't support by the module yet.

So i submit the code to support this.

`db.child("somepath").order_by_child('a/b/c')`

the line above will not throw an error with my patch.
