### PR TITLE
Fix key generation bug

### DIFF
--- a/pyrebase/pyrebase.py
+++ b/pyrebase/pyrebase.py
@@ -8,7 +8,7 @@ except:
     from urllib import urlencode, quote
 import json
 import math
-from random import uniform
+from random import randrange
 import time
 from collections import OrderedDict
 from sseclient import SSEClient
@@ -338,8 +338,7 @@ class Database:
             now = int(math.floor(now / 64))
         new_id = "".join(time_stamp_chars)
         if not duplicate_time:
-            for i in range(0, 12):
-                self.last_rand_chars.append(int(math.floor(uniform(0, 1) * 64)))
+            self.last_rand_chars = [randrange(63) for _ in range(12)]
         else:
             for i in range(0, 11):
                 if self.last_rand_chars[i] == 63:


### PR DESCRIPTION
Firebase keys should be made up of 120 bits - 48 bits for timestamp and 72 bits of randomness ((reference[https://firebase.googleblog.com/2015/02/the-2120-ways-to-ensure-unique_68.html]). There is a bug in `generate_key()` method due to which those 72 random bits are the same for all generated keys, unless the timestamp part is the same. Moreover, there is an ever-growing array of random data that is newer used (`Database.last_rand_chars`). For more info, see the commit message.