### PR TITLE
Add API for deleting the user account

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,11 @@ auth.get_account_info(user['idToken'])
 user = auth.refresh(user['refreshToken'])
 ```
 
+#### Delete account
+```python
+auth.delete_user_account(user['idToken'])
+```
+
 ## Database
 
 You can build paths to your data by using the ```child()``` method.

--- a/pyrebase/pyrebase.py
+++ b/pyrebase/pyrebase.py
@@ -163,6 +163,14 @@ class Auth:
         raise_detailed_error(request_object)
         return request_object.json()
 
+    def delete_user_account(self, id_token):
+        request_ref = "https://www.googleapis.com/identitytoolkit/v3/relyingparty/deleteAccount?key={0}".format(self.api_key)
+        headers = {"content-type": "application/json; charset=UTF-8"}
+        data = json.dumps({"idToken": id_token})
+        request_object = requests.post(request_ref, headers=headers, data=data)
+        raise_detailed_error(request_object)
+        return request_object.json()
+
 
 class Database:
     """ Database Service """


### PR DESCRIPTION
Add an API to the Auth class that deletes the current user account via the id_token.

I need this API to aid with testing the user enrollment process on my app.

https://firebase.google.com/docs/reference/rest/auth/#section-delete-account