### PR TITLE
Fix exception if file is not on server

### DIFF
--- a/pyrebase/pyrebase.py
+++ b/pyrebase/pyrebase.py
@@ -418,7 +418,8 @@ class Storage:
             path = path[1:]
         if self.credentials:
             blob = self.bucket.get_blob(path)
-            blob.download_to_filename(filename)
+            if not blob is None:
+                blob.download_to_filename(filename)
         else:
             r = requests.get(url, stream=True)
             if r.status_code == 200:


### PR DESCRIPTION
Hi all,
I hit the exception when calling storage download method.
This is because the file is not on the firebase server, and blob is returned as None object.
Is there any method to check if file locates on the server before download?
Or we need to prevent calling download_to_filename method on a None object?
Thanks! 
---- 
Fix exception error due to the fact that file is not on server that
cause blob is None object and hence calling method fails:
AttributeError: 'NoneType' object has no attribute 'download_to_filename'