### PR TITLE
Use google-auth instead of oauth2client

### DIFF
--- a/pyrebase/__init__.py
+++ b/pyrebase/__init__.py
@@ -1,1 +1,1 @@
-from .pyrebase import initialize_app
+from .pyrebase import initialize_app  # noqa

--- a/pyrebase/pyrebase.py
+++ b/pyrebase/pyrebase.py
@@ -7,9 +7,9 @@ import socket
 import threading
 import time
 
-from gcloud import storage
 from google.auth import jwt
 from google.auth.transport.requests import AuthorizedSession
+from google.cloud import storage
 from google.oauth2 import service_account
 import requests
 from requests.exceptions import HTTPError

--- a/pyrebase/pyrebase.py
+++ b/pyrebase/pyrebase.py
@@ -1,5 +1,4 @@
 from collections import OrderedDict
-import datetime
 import json
 import math
 from random import uniform
@@ -20,7 +19,7 @@ from sseclient import SSEClient
 
 try:
     from urllib.parse import urlencode, quote
-except:
+except ImportError:
     from urllib import urlencode, quote
 
 
@@ -168,7 +167,7 @@ class Auth:
 
     def create_user_with_email_and_password(self, email, password):
         request_ref = "https://www.googleapis.com/identitytoolkit/v3/relyingparty/signupNewUser?key={0}".format(self.api_key)
-        headers = {"content-type": "application/json; charset=UTF-8" }
+        headers = {"content-type": "application/json; charset=UTF-8"}
         data = json.dumps({"email": email, "password": password, "returnSecureToken": True})
         request_object = requests.post(request_ref, headers=headers, data=data)
         raise_detailed_error(request_object)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
-requests==2.11.1
-gcloud==0.17.0
-oauth2client==3.0.0
-requests-toolbelt==0.7.0
-python-jwt==2.0.1
-pycrypto==2.6.1
+requests>=2.11.0
+gcloud>=0.17.0
+google-auth>=1.4.0
+requests-toolbelt>=0.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-requests>=2.11.0
-gcloud>=0.17.0
+requests>=2.18.0
+google-cloud-storage>=1.8.0
 google-auth>=1.4.0
 requests-toolbelt>=0.7.0

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     packages=find_packages(exclude=['tests']),
     install_requires=[
         'requests>=2.11.0',
-        'gcloud>=0.17.0',
+        'google-cloud-storage>=1.8.0',
         'google-auth>=1.4.0',
         'requests-toolbelt>=0.7.0',
     ]

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='Pyrebase',
-    version='3.0.27',
+    version='3.1.0',
     url='https://github.com/thisbejim/Pyrebase',
     description='A simple python wrapper for the Firebase API',
     author='James Childs-Maidment',
@@ -16,11 +16,9 @@ setup(
     keywords='Firebase',
     packages=find_packages(exclude=['tests']),
     install_requires=[
-        'requests==2.11.1',
-        'gcloud==0.17.0',
-        'oauth2client==3.0.0',
-        'requests_toolbelt==0.7.0',
-        'python_jwt==2.0.1',
-        'pycryptodome==3.4.3'
+        'requests>=2.11.0',
+        'gcloud>=0.17.0',
+        'google-auth>=1.4.0',
+        'requests-toolbelt>=0.7.0',
     ]
 )

--- a/sseclient/__init__.py
+++ b/sseclient/__init__.py
@@ -1,1 +1,1 @@
-from .sseclient import SSEClient
+from .sseclient import SSEClient  # noqa

--- a/sseclient/sseclient.py
+++ b/sseclient/sseclient.py
@@ -1,15 +1,14 @@
 import re
 import time
 import warnings
-import threading
 import six
 
 import requests
 
-
 # Technically, we should support streams that mix line endings.  This regex,
 # however, assumes that a system will provide consistent line endings.
 end_of_field = re.compile(r'\r\n\r\n|\r\r|\n\n')
+
 
 class SSEClient(object):
     def __init__(self, url, session, build_headers, last_id=None, retry=3000, **kwargs):

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -72,7 +72,7 @@ class TestJsonKwargs:
 
     def decoder(self, obj):
         if '__type__' in obj and obj['__type__'] == datetime.datetime.__name__:
-            return datetime.datetime.utcfromtimestamp(obj['value'])
+            return datetime.datetime.fromtimestamp(obj['value'])
         return obj
 
     def test_put_fail(self, db_sa):

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -131,6 +131,6 @@ class TestStreaming:
             db_sa().update({"2": "c"})
             db_sa().push("3")
 
-            time.sleep(2)
+            time.sleep(3)
 
             assert len(l) == 3


### PR DESCRIPTION
This replaces the now deprecated [oauth2client](https://github.com/google/oauth2client) with [google-auth](https://github.com/GoogleCloudPlatform/google-auth-library-python). This should fix issues with token expiration.

n.b. I also sorted the imports at the top of `pyrebase.py` to be compliant with PEP 8.