### PR TITLE
Unpinned requests deps: so it pyrebase will work in project that have newer deps and pip 10.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-requests==2.11.1
+requests>=2.11.1
 gcloud==0.17.0
 oauth2client==3.0.0
-requests-toolbelt==0.7.0
+requests-toolbelt>=0.7.0
 python-jwt==2.0.1
 pycrypto==2.6.1

--- a/setup.py
+++ b/setup.py
@@ -16,10 +16,10 @@ setup(
     keywords='Firebase',
     packages=find_packages(exclude=['tests']),
     install_requires=[
-        'requests==2.11.1',
+        'requests>=2.11.1',
         'gcloud==0.17.0',
         'oauth2client==3.0.0',
-        'requests_toolbelt==0.7.0',
+        'requests_toolbelt>=0.7.0',
         'python_jwt==2.0.1',
         'pycryptodome==3.4.3'
     ]


### PR DESCRIPTION
With pip 10.0 had errors preventing PyRebase to install correctly as the project uses and 'up to date' requests.  Older version of pip seem fine.