### PR TITLE
Updated README.md 

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,7 +396,7 @@ storage.child("images/example.jpg").download("downloaded.jpg")
 The get_url method takes the path to the saved database file and returns the storage url.
 
 ```
-storage.child("images/example.jpg").get_url()
+storage.child("images/example.jpg").get_url(None)
 # https://firebasestorage.googleapis.com/v0/b/storage-url.appspot.com/o/images%2Fexample.jpg?alt=media
 ```
 


### PR DESCRIPTION
get_url needs a token, pass 'None' to ignore this error message

TypeError: get_url() missing 1 required positional argument: 'token'