### PR TITLE
fix(Auth): Use caller's requests.session object

### DIFF
--- a/pyrebase/pyrebase.py
+++ b/pyrebase/pyrebase.py
@@ -81,7 +81,7 @@ class Auth:
         request_ref = "https://www.googleapis.com/identitytoolkit/v3/relyingparty/verifyPassword?key={0}".format(self.api_key)
         headers = {"content-type": "application/json; charset=UTF-8"}
         data = json.dumps({"email": email, "password": password, "returnSecureToken": True})
-        request_object = requests.post(request_ref, headers=headers, data=data)
+        request_object = self.requests.post(request_ref, headers=headers, data=data)
         raise_detailed_error(request_object)
         self.current_user = request_object.json()
         return request_object.json()
@@ -104,7 +104,7 @@ class Auth:
         request_ref = "https://www.googleapis.com/identitytoolkit/v3/relyingparty/verifyCustomToken?key={0}".format(self.api_key)
         headers = {"content-type": "application/json; charset=UTF-8"}
         data = json.dumps({"returnSecureToken": True, "token": token})
-        request_object = requests.post(request_ref, headers=headers, data=data)
+        request_object = self.requests.post(request_ref, headers=headers, data=data)
         raise_detailed_error(request_object)
         return request_object.json()
 
@@ -112,7 +112,7 @@ class Auth:
         request_ref = "https://securetoken.googleapis.com/v1/token?key={0}".format(self.api_key)
         headers = {"content-type": "application/json; charset=UTF-8"}
         data = json.dumps({"grantType": "refresh_token", "refreshToken": refresh_token})
-        request_object = requests.post(request_ref, headers=headers, data=data)
+        request_object = self.requests.post(request_ref, headers=headers, data=data)
         raise_detailed_error(request_object)
         request_object_json = request_object.json()
         # handle weirdly formatted response
@@ -127,7 +127,7 @@ class Auth:
         request_ref = "https://www.googleapis.com/identitytoolkit/v3/relyingparty/getAccountInfo?key={0}".format(self.api_key)
         headers = {"content-type": "application/json; charset=UTF-8"}
         data = json.dumps({"idToken": id_token})
-        request_object = requests.post(request_ref, headers=headers, data=data)
+        request_object = self.requests.post(request_ref, headers=headers, data=data)
         raise_detailed_error(request_object)
         return request_object.json()
 
@@ -135,7 +135,7 @@ class Auth:
         request_ref = "https://www.googleapis.com/identitytoolkit/v3/relyingparty/getOobConfirmationCode?key={0}".format(self.api_key)
         headers = {"content-type": "application/json; charset=UTF-8"}
         data = json.dumps({"requestType": "VERIFY_EMAIL", "idToken": id_token})
-        request_object = requests.post(request_ref, headers=headers, data=data)
+        request_object = self.requests.post(request_ref, headers=headers, data=data)
         raise_detailed_error(request_object)
         return request_object.json()
 
@@ -143,7 +143,7 @@ class Auth:
         request_ref = "https://www.googleapis.com/identitytoolkit/v3/relyingparty/getOobConfirmationCode?key={0}".format(self.api_key)
         headers = {"content-type": "application/json; charset=UTF-8"}
         data = json.dumps({"requestType": "PASSWORD_RESET", "email": email})
-        request_object = requests.post(request_ref, headers=headers, data=data)
+        request_object = self.requests.post(request_ref, headers=headers, data=data)
         raise_detailed_error(request_object)
         return request_object.json()
 
@@ -151,7 +151,7 @@ class Auth:
         request_ref = "https://www.googleapis.com/identitytoolkit/v3/relyingparty/resetPassword?key={0}".format(self.api_key)
         headers = {"content-type": "application/json; charset=UTF-8"}
         data = json.dumps({"oobCode": reset_code, "newPassword": new_password})
-        request_object = requests.post(request_ref, headers=headers, data=data)
+        request_object = self.requests.post(request_ref, headers=headers, data=data)
         raise_detailed_error(request_object)
         return request_object.json()
 
@@ -159,7 +159,7 @@ class Auth:
         request_ref = "https://www.googleapis.com/identitytoolkit/v3/relyingparty/signupNewUser?key={0}".format(self.api_key)
         headers = {"content-type": "application/json; charset=UTF-8" }
         data = json.dumps({"email": email, "password": password, "returnSecureToken": True})
-        request_object = requests.post(request_ref, headers=headers, data=data)
+        request_object = self.requests.post(request_ref, headers=headers, data=data)
         raise_detailed_error(request_object)
         return request_object.json()
 


### PR DESCRIPTION
I needed to set a `Referer` header and wasn't able to since this was using the naked 
requests object from the module import, instead of the one passed in to `__init__`