### PR TITLE
fix storage get_url bug

### DIFF
--- a/pyrebase/pyrebase.py
+++ b/pyrebase/pyrebase.py
@@ -426,7 +426,7 @@ class Storage:
                     for chunk in r:
                         f.write(chunk)
 
-    def get_url(self, token):
+    def get_url(self, token=None):
         path = self.path
         self.path = None
         if path.startswith('/'):


### PR DESCRIPTION
Hello pyrebase team,
I loved the work that you've done. This lib is far more easy than firebase_admin. I appreciate it. There was a small bug (typo maybe), you didn't give default value to the positional argument token in function get_url() in class Storage. I updated it, checked on my machine (works as expected now). Hope you update it soon.