### PR TITLE
Fixed storage get_url() token bug

### DIFF
--- a/pyrebase/pyrebase.py
+++ b/pyrebase/pyrebase.py
@@ -426,7 +426,7 @@ class Storage:
                     for chunk in r:
                         f.write(chunk)
 
-    def get_url(self, token):
+    def get_url(self, token=None):
         path = self.path
         self.path = None
         headers = {}


### PR DESCRIPTION
The current get_url method takes the bearer token as a token URL parameter which in fact is a different token, named access token or download token. 

I have changed the method so that it works for all types of firebase storage rules by retrieving the access token first and passing it into the URL.

Before the get_url() method returns 
![image](https://user-images.githubusercontent.com/91376371/162609758-4bb7f686-010c-48d3-ae34-7c626945e63b.png)

After changes, it returns the url with correct token
![image](https://user-images.githubusercontent.com/91376371/162609777-c476e244-bd43-4677-8dbe-bdf8b6b30213.png)
