### PR TITLE
[update] if don't have a apiKey, get the key from serviceAccount.json

### DIFF
--- a/pyrebase/pyrebase.py
+++ b/pyrebase/pyrebase.py
@@ -31,7 +31,12 @@ def initialize_app(config):
 class Firebase:
     """ Firebase Interface """
     def __init__(self, config):
-        self.api_key = config["apiKey"]
+        if config.get("apiKey"):
+            self.api_key = config["apiKey"]
+        else:
+            with open(config["serviceAccount"],'r') as file:
+                data = file.read()
+                self.api_key = json.loads(data)["private_key"]
         self.auth_domain = config["authDomain"]
         self.database_url = config["databaseURL"]
         self.storage_bucket = config["storageBucket"]


### PR DESCRIPTION
# this code allow get the private_key from serviceAccount.json if don't have a apiKey

hello, as it says in issue #98, a user could authenticate with just the serviceAccount.json file, so I made this small change in the code so that **if you don't have an api key in config** then look in the file ***serviceAccount.json*** the **api key**

### changes:
``` python
class Firebase:
    """ Firebase Interface """
    def __init__(self, config):
        if config.get("apiKey"):
            self.api_key = config["apiKey"]
        else:
            with open(config["serviceAccount"],'r') as file:
                data = file.read()
                self.api_key = json.loads(data)["private_key"]
```