### PR TITLE
Update pyrebase.py to enable capturing metadata with service account enabled

### DIFF
--- a/pyrebase/pyrebase.py
+++ b/pyrebase/pyrebase.py
@@ -400,7 +400,11 @@ class Storage:
             if isinstance(file, str):
                 return blob.upload_from_filename(filename=file)
             else:
-                return blob.upload_from_file(file_obj=file)
+                # i witnessed an issue that when i set the service acount json , blob.upload_from_file(file_obj=file) returns none instead of the metadata
+                request_object = self.requests.post(request_ref, data=file_object)
+                raise_detailed_error(request_object)
+                return request_object.json() # this returns the metadata
+#                 return blob.upload_from_file(file_obj=file)
         else:
             request_object = self.requests.post(request_ref, data=file_object)
             raise_detailed_error(request_object)


### PR DESCRIPTION
Recently while working with the delete feature in pyrebase in added the service account which enabled the credentials in Storage object.

Therefore the upload was being established but i got this error ; TypeError: 'NoneType' object is not subscriptable
 where metadata was not being  returned since its used the ```blob.upload_from_file(file_obj) ``` return None
 
```
        elif self.credentials:
            blob = self.bucket.blob(path)
            if isinstance(file, str):
                return blob.upload_from_filename(filename=file)
            else:
                 return blob.upload_from_file(file_obj=file)
        else:
            request_object = self.requests.post(request_ref, data=file_object)
            raise_detailed_error(request_object)
            return request_object.json()
```

Moving this code :+1:
 ```
            request_object = self.requests.post(request_ref, data=file_object)
            raise_detailed_error(request_object)
            return request_object.json()
```
 inside the else statement located in the ```elif self.credentials```  made it to return the metadata pretty well when uploading a file object 

## Check it out if possible merge it . It really helped me out
